### PR TITLE
Increase Earthquake Marker Stale Time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,8 +1028,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@orbat-mapper/convert-symbology/-/convert-symbology-1.0.2.tgz",
             "integrity": "sha512-FpnPXS16/C+ay7FVPLhTkRH2NmREKxhJ+pifqcW9NpsbORH94S14qU8Eyl2ofMP7upxQYNvw2qpTok5I3P4QKw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -1037,7 +1036,6 @@
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -1046,36 +1044,31 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
             "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
             "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
             "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
             "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
             "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1",
                 "@protobufjs/inquire": "^1.1.0"
@@ -1085,36 +1078,31 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
             "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
             "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
             "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.41",
@@ -1804,7 +1792,6 @@
             "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.2.0.tgz",
             "integrity": "sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -1820,7 +1807,6 @@
             "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.2.0.tgz",
             "integrity": "sha512-lvEOjxeXIp+wPXgl9kJA97dqzMfNexjqHou+XHVcfxQgolctoJiRYmcVCWGpiZ9CBf/CJha1KmD1qQoRIsjLaA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -1837,7 +1823,6 @@
             "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.2.0.tgz",
             "integrity": "sha512-UTNp9abQ2kuyRg5gCIGDNwwEQeF3NbpYsd1Q0KW9lwWuzbLVNn0sOwbxjpNF4J2HtMOs5YVOcqNvYyuoa2XrXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/bbox": "^7.2.0",
                 "@turf/helpers": "^7.2.0",
@@ -1853,7 +1838,6 @@
             "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.2.0.tgz",
             "integrity": "sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -1869,7 +1853,6 @@
             "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.2.0.tgz",
             "integrity": "sha512-1AbqBYtXhstrHmnW6jhLwsv7TtmT0mW58Hvl1uZXEDM1NCVXIR50yDipIeQPjrCuJ/Zdg/91gU8+4GuDCAxBGA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/destination": "^7.2.0",
                 "@turf/helpers": "^7.2.0",
@@ -1885,7 +1868,6 @@
             "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.2.0.tgz",
             "integrity": "sha512-JlGUT+/5qoU5jqZmf6NMFIoLDY3O7jKd53Up+zbpJ2vzUp6QdwdNzwrsCeONhynWM13F0MVtPXH4AtdkrgFk4g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@types/geojson": "^7946.0.10",
@@ -1900,7 +1882,6 @@
             "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.2.0.tgz",
             "integrity": "sha512-8DUxtOO0Fvrh1xclIUj3d9C5WS20D21F5E+j+X9Q+ju6fcM4huOqTg5ckV1DN2Pg8caABEc5HEZJnGch/5YnYQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -1916,7 +1897,6 @@
             "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.2.0.tgz",
             "integrity": "sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -1932,7 +1912,6 @@
             "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.2.0.tgz",
             "integrity": "sha512-/Y75S5hE2+xjnTw4dXpQ5r/Y2HPM4xrwkPRCCQRpuuboKdEvm42azYmh7isPnMnBTVcmGb9UmGKj0HHAbiwt1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -1950,7 +1929,6 @@
             "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.2.0.tgz",
             "integrity": "sha512-jyMXg93J1OI7/65SsLE1k9dfQD3JbcPNMi4/O3QR2Qb3BAs2039oFaSjtW+YqhMqVC4V3ZeKebMcJ8h9sK1n+A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -1966,7 +1944,6 @@
             "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
             "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/geojson": "^7946.0.10",
                 "tslib": "^2.8.1"
@@ -1980,7 +1957,6 @@
             "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
             "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@types/geojson": "^7946.0.10",
@@ -1995,7 +1971,6 @@
             "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.2.0.tgz",
             "integrity": "sha512-kfWzA5oYrTpslTg5fN50G04zSypiYQzjZv3FLjbZkk6kta5fo4JkERKjTeA8x4XNojb+pfmjMBB0yIh2w2dDRw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/circle": "^7.2.0",
                 "@turf/destination": "^7.2.0",
@@ -2012,7 +1987,6 @@
             "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
             "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@types/geojson": "^7946.0.10"
@@ -2026,7 +2000,6 @@
             "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.2.0.tgz",
             "integrity": "sha512-0wmsqXZ8CGw4QKeZmS+NdjYTqCMC+HXZvM3XAQIU6k6laNLqjad2oS4nDrtcRs/nWDvcj1CR+Io7OiQ6sbpn5Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/clone": "^7.2.0",
                 "@turf/distance": "^7.2.0",
@@ -2044,7 +2017,6 @@
             "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.2.0.tgz",
             "integrity": "sha512-ksoYoLO9WtJ/qI8VI9ltF+2ZjLWrAjZNsCsu8F7nyGeCh4I8opjf4qVLytFG44XA2qI5yc6iXDpyv0sshvP82Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/boolean-point-in-polygon": "^7.2.0",
                 "@turf/center": "^7.2.0",
@@ -2063,7 +2035,6 @@
             "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.2.0.tgz",
             "integrity": "sha512-jbdexlrR8X2ZauUciHx3tRwG+BXoMXke4B8p8/IgDlAfIrVdzAxSQN89FMzIKnjJ/kdLjo9bFGvb92bu31Etug==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -2079,7 +2050,6 @@
             "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.2.0.tgz",
             "integrity": "sha512-U9OLgLAHlH4Wfx3fBZf3jvnkDjdTcfRan5eI7VPV1+fQWkOteATpzkiRjCvSYK575GljVwWBjkKca8LziGWitQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -2095,7 +2065,6 @@
             "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.2.0.tgz",
             "integrity": "sha512-NsijTPON1yOc9tirRPEQQuJ5aQi7pREsqchQquaYKbHNWsexZjcDi4wnw2kM3Si4XjmgynT+2f7aXH7FHarHzw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/invariant": "^7.2.0",
@@ -2111,7 +2080,6 @@
             "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.2.0.tgz",
             "integrity": "sha512-zL06MjbbMG4DdpiNz+Q9Ax8jsCekt3R76uxeWShulAGkyDB5smdBOUDoRwxn05UX7l4kKv4Ucq2imQXhxKFd1w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/circle": "^7.2.0",
                 "@turf/helpers": "^7.2.0",
@@ -2130,7 +2098,6 @@
             "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.2.0.tgz",
             "integrity": "sha512-EMCj0Zqy3cF9d3mGRqDlYnX2ZBXe3LgT+piDR0EuF5c5sjuKErcFcaBIsn/lg1gp4xCNZFinkZ3dsFfgGHf6fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/centroid": "^7.2.0",
                 "@turf/clone": "^7.2.0",
@@ -2152,7 +2119,6 @@
             "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.2.0.tgz",
             "integrity": "sha512-jyFzxYbPugK4XjV5V/k6Xr3taBjjvo210IbPHJXw0Zh7Y6sF+hGxeRVtSuZ9VP/6oRyqAOHKUrze+OOkPqBgUg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@turf/helpers": "^7.2.0",
                 "@turf/meta": "^7.2.0",
@@ -2168,7 +2134,6 @@
             "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
             "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/readdir-glob": "*"
             }
@@ -2289,6 +2254,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
             "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -2310,7 +2276,6 @@
             "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
             "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -2391,6 +2356,7 @@
             "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.2",
                 "@typescript-eslint/types": "8.46.2",
@@ -2608,7 +2574,6 @@
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -2635,6 +2600,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2748,7 +2714,6 @@
             "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
             "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "archiver-utils": "^5.0.2",
                 "async": "^3.2.4",
@@ -2767,7 +2732,6 @@
             "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
             "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "glob": "^10.0.0",
                 "graceful-fs": "^4.2.0",
@@ -2786,17 +2750,15 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/archiver-utils/node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -2817,7 +2779,6 @@
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
             "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "license": "BlueOak-1.0.0",
-            "peer": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -2832,15 +2793,13 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/archiver-utils/node_modules/minimatch": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -2856,7 +2815,6 @@
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "license": "BlueOak-1.0.0",
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -2886,15 +2844,13 @@
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
             "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/b4a": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
             "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
             "license": "Apache-2.0",
-            "peer": true,
             "peerDependencies": {
                 "react-native-b4a": "*"
             },
@@ -2915,7 +2871,6 @@
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.1.tgz",
             "integrity": "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "peerDependencies": {
                 "bare-abort-controller": "*"
             },
@@ -2943,8 +2898,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/basic-auth": {
             "version": "2.0.1",
@@ -2965,23 +2919,27 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-            "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+            "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
                 "content-type": "^1.0.5",
-                "debug": "^4.4.0",
+                "debug": "^4.4.3",
                 "http-errors": "^2.0.0",
-                "iconv-lite": "^0.6.3",
+                "iconv-lite": "^0.7.0",
                 "on-finished": "^2.4.1",
                 "qs": "^6.14.0",
-                "raw-body": "^3.0.0",
-                "type-is": "^2.0.0"
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/bowser": {
@@ -3033,7 +2991,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
@@ -3044,7 +3001,6 @@
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
             "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -3125,7 +3081,6 @@
             "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
             "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "color-convert": "^3.0.1",
                 "color-string": "^2.0.0"
@@ -3139,7 +3094,6 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
             "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "color-name": "^2.0.0"
             },
@@ -3152,7 +3106,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
             "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12.20"
             }
@@ -3162,7 +3115,6 @@
             "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
             "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "color-name": "^2.0.0"
             },
@@ -3175,7 +3127,6 @@
             "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
             "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "crc-32": "^1.2.0",
                 "crc32-stream": "^6.0.0",
@@ -3237,15 +3188,13 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/crc-32": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
             "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "crc32": "bin/crc32.njs"
             },
@@ -3258,7 +3207,6 @@
             "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
             "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "crc-32": "^1.2.0",
                 "readable-stream": "^4.0.0"
@@ -3436,6 +3384,7 @@
             "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3622,7 +3571,6 @@
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3632,7 +3580,6 @@
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -3642,7 +3589,6 @@
             "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
             "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "bare-events": "^2.7.0"
             }
@@ -3699,8 +3645,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
@@ -3918,8 +3863,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/geomagnetism/-/geomagnetism-0.2.0.tgz",
             "integrity": "sha512-dO8HJrXqah244nMe+pU5m52L90SMoi4lDA0AV3xunRxogloYV+s3aYWCW72VMMfiYis+YSAlhoKktw8aLMiJbw==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
@@ -3959,14 +3903,14 @@
             }
         },
         "node_modules/glob": {
-            "version": "11.0.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-            "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-            "license": "ISC",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "foreground-child": "^3.3.1",
                 "jackspeak": "^4.1.1",
-                "minimatch": "^10.0.3",
+                "minimatch": "^10.1.1",
                 "minipass": "^7.1.2",
                 "package-json-from-dist": "^1.0.0",
                 "path-scurry": "^2.0.0"
@@ -3995,10 +3939,10 @@
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-            "license": "ISC",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/brace-expansion": "^5.0.0"
             },
@@ -4038,8 +3982,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -4108,15 +4051,19 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+            "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/ieee754": {
@@ -4137,8 +4084,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "5.3.2",
@@ -4245,7 +4191,6 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -4257,8 +4202,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -4282,9 +4226,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4305,8 +4249,7 @@
             "version": "4.8.2",
             "resolved": "https://registry.npmjs.org/json-diff-ts/-/json-diff-ts-4.8.2.tgz",
             "integrity": "sha512-7LgOTnfK5XnBs0o0AtHTkry5QGZT7cSlAgu5GtiomUeoHqOavAUDcONNm/bCe4Lapt0AHnaidD5iSE+ItvxKkA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -4355,12 +4298,12 @@
             }
         },
         "node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+            "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
             "license": "MIT",
             "dependencies": {
-                "jwa": "^1.4.1",
+                "jwa": "^1.4.2",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -4379,7 +4322,6 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
             "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "readable-stream": "^2.0.5"
             },
@@ -4392,7 +4334,6 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -4407,15 +4348,13 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lazystream/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -4454,8 +4393,7 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.includes": {
             "version": "4.3.0",
@@ -4510,8 +4448,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
             "version": "11.2.2",
@@ -4587,8 +4524,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/milsymbol/-/milsymbol-3.0.3.tgz",
             "integrity": "sha512-Fy/32WaGwitTTaILyLVxsh/pHsiBVKKieC0Ply/LRWLrOGivOB96WjGXSRWlWmXLI+wfoO6/vDfjwR7tyP47fA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/mime-db": {
             "version": "1.54.0",
@@ -4733,7 +4669,6 @@
             "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
             "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             },
@@ -4747,7 +4682,6 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4941,7 +4875,6 @@
             "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
             "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "robust-predicates": "^3.0.2"
             }
@@ -4961,7 +4894,6 @@
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -4970,8 +4902,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/protobufjs": {
             "version": "7.5.4",
@@ -4979,7 +4910,6 @@
             "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -5102,7 +5032,6 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
             "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
@@ -5119,7 +5048,6 @@
             "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
             "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "minimatch": "^5.1.0"
             }
@@ -5129,7 +5057,6 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -5139,7 +5066,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
             "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -5182,7 +5108,6 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
             "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^11.0.0",
                 "package-json-from-dist": "^1.0.0"
@@ -5201,8 +5126,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
             "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-            "license": "Unlicense",
-            "peer": true
+            "license": "Unlicense"
         },
         "node_modules/router": {
             "version": "2.2.0",
@@ -5274,8 +5198,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
             "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/semver": {
             "version": "7.7.3",
@@ -5451,7 +5374,6 @@
             "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
             "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "events-universal": "^1.0.0",
                 "fast-fifo": "^1.3.2",
@@ -5463,7 +5385,6 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -5607,7 +5528,6 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
@@ -5619,7 +5539,6 @@
             "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
             "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "b4a": "^1.6.4"
             }
@@ -5742,6 +5661,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5812,8 +5732,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/uuid": {
             "version": "13.0.0",
@@ -5824,7 +5743,6 @@
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "uuid": "dist-node/bin/uuid"
             }
@@ -5969,7 +5887,6 @@
             "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
             "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "sax": "^1.2.4"
             },
@@ -6005,7 +5922,6 @@
             "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
             "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "archiver-utils": "^5.0.0",
                 "compress-commons": "^6.0.2",

--- a/task.ts
+++ b/task.ts
@@ -128,6 +128,7 @@ export default class Task extends ETL {
                         icon: MMI_ICONS[props.mmi] || 'bb4df0a6-ca8d-4ba8-bb9e-3deb97ff015e:NaturalHazards/NH.24.Earthquake.png',
                         time: props.time,
                         start: props.time,
+                        stale: new Date(Date.now() + 5 * 60 * 1000).toISOString(),
                         remarks: [
                             `Magnitude: ${props.magnitude.toFixed(2)}`,
                             `MMI: ${props.mmi}`,


### PR DESCRIPTION
### Changes
- Added explicit `stale` property to earthquake features
- Set stale time to 5 minutes from ETL execution time
- Replaces default 20-second stale timeout

### Benefits
- Earthquake markers remain visible for 5 minutes instead of 20 seconds
- Consistent with other ETL stale time patterns (inreach: 15min, metlink: 3min)
- Improves user experience by keeping earthquake data visible longer

### Technical Details
- Stale time calculated as `Date.now() + 5 * 60 * 1000` (5 minutes from now)
- Applied to all earthquake features regardless of when earthquake occurred
